### PR TITLE
Fix bug at 15 seconds until despawn.

### DIFF
--- a/src/main/java/ejedev/chompyhunter/ChompyHunterOverlay.java
+++ b/src/main/java/ejedev/chompyhunter/ChompyHunterOverlay.java
@@ -43,7 +43,7 @@ public class ChompyHunterOverlay extends Overlay {
             if(timeLeft < 30 && timeLeft > 15) {
                 color = Color.ORANGE;
             }
-            else if(timeLeft< 15) {
+            else if(timeLeft<= 15) {
                 color = Color.RED;
             }
             if (chompy.getNpc().getName() != null && chompy.getNpc().getId() == 1475 && timeLeft > -1)


### PR DESCRIPTION
Fixes a bug where chompies would be highlighted in green at 15 seconds before their despawn, due to neither inequality being "or equal to" 15.